### PR TITLE
Update 7zip detection script to handle missing file

### DIFF
--- a/scripts/7zip-detection.ps1
+++ b/scripts/7zip-detection.ps1
@@ -1,14 +1,22 @@
-$FileVersion = [System.Diagnostics.FileVersionInfo]::GetVersionInfo("C:\Program Files\7-Zip\7z.exe").FileVersion
-#The below line trims the spaces before and after the version name
-$FileVersion = $FileVersion.Trim();
+$filePath = "C:\Program Files\7-Zip\7z.exe"
+
+if (-not (Test-Path $filePath)) {
+    Write-Output "7-Zip executable not found at $filePath"
+    exit 1
+}
+
+$FileVersion = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($filePath).FileVersion
+# The below line trims the spaces before and after the version name
+$FileVersion = $FileVersion.Trim()
+
 if ("24.09" -eq $FileVersion)
 {
-#Write the version to STDOUT by default
-$FileVersion
-exit 0
+    # Write the version to STDOUT by default
+    $FileVersion
+    exit 0
 }
 else
 {
-#Exit with non-zero failure code
-exit 1
+    # Exit with non-zero failure code
+    exit 1
 }


### PR DESCRIPTION
## Summary
- check for 7-Zip executable before getting file version
- output warning and exit with code 1 if file is missing

## Testing
- `pwsh` command was unavailable, so script execution wasn't tested


------
https://chatgpt.com/codex/tasks/task_b_684f6a7ca8bc8324a32b60ea58c54e3b