### PR TITLE
Add comment-based help to 7zip detection script

### DIFF
--- a/scripts/7zip-detection.ps1
+++ b/scripts/7zip-detection.ps1
@@ -1,3 +1,23 @@
+<#
+.SYNOPSIS
+Checks the installed version of 7-Zip.
+
+.DESCRIPTION
+The script locates the 7-Zip executable in standard installation paths and
+compares its file version to the value provided via the **ExpectedVersion**
+parameter. When the detected version matches, the script returns the version
+string and exits with code 0. A mismatch or missing executable results in a
+non-zero exit code.
+
+.PARAMETER ExpectedVersion
+The version number to compare against the installed 7-Zip. The default value is
+`24.09`.
+
+.EXAMPLE
+PS> .\7zip-detection.ps1 -ExpectedVersion '24.09'
+Verifies that 7-Zip version 24.09 is installed on the system.
+#>
+
 param([string]$ExpectedVersion = '24.09')
 
 $primaryPath = "C:\Program Files\7-Zip\7z.exe"


### PR DESCRIPTION
## Summary
- add PowerShell help block to `7zip-detection.ps1`

## Testing
- `pwsh -NoLogo -Command "Get-Help ./scripts/7zip-detection.ps1 -Detailed" | head` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684f72dcd1b88324a4c83a840860478d