### PR TITLE
Fix ProgramFiles(x86) path in 7zip detection

### DIFF
--- a/scripts/7zip-detection.ps1
+++ b/scripts/7zip-detection.ps1
@@ -21,7 +21,7 @@ Verifies that 7-Zip version 24.09 is installed on the system.
 param([string]$ExpectedVersion = '24.09')
 
 $primaryPath = "C:\Program Files\7-Zip\7z.exe"
-$secondaryPath = "C:\Program Files (x86)\7-Zip\7z.exe"
+$secondaryPath = "${env:ProgramFiles(x86)}\7-Zip\7z.exe"
 
 if (Test-Path $primaryPath) {
     $filePath = $primaryPath


### PR DESCRIPTION
## Summary
- handle `ProgramFiles(x86)` environment variable properly

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_684f759f7dec832488ff578dfda030c9