### PR TITLE
Add stderr message for missing 7-Zip

### DIFF
--- a/scripts/7zip-detection.ps1
+++ b/scripts/7zip-detection.ps1
@@ -29,6 +29,7 @@ if (Test-Path $primaryPath) {
     $filePath = $secondaryPath
 } else {
     Write-Output "7-Zip executable not found"
+    Write-Error "7-Zip executable not found"
     exit 1
 }
 


### PR DESCRIPTION
## Summary
- output an error to STDERR before failing 7zip detection script

## Testing
- `pwsh -NoProfile -Command ./scripts/7zip-detection.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684f82c666348324aa608c75117db87d